### PR TITLE
Enable IoT Hub fallback route

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: MIT
-# Copyright Contributors to the Open Manufacturing Platform
-#
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/dotnetcore/.devcontainer/base.Dockerfile
 
 # Dependencies versions

--- a/terraform-dps/modules/iot-hub/main.tf
+++ b/terraform-dps/modules/iot-hub/main.tf
@@ -24,10 +24,8 @@ resource "azurerm_iothub" "sense" {
     capacity = "1"
   }
 
-  route {
-    name           = "defaultroute"
+  fallback_route {
     source         = "DeviceMessages"
-    condition      = "true"
     endpoint_names = ["events"]
     enabled        = true
   }

--- a/terraform/modules/iot-hub/main.tf
+++ b/terraform/modules/iot-hub/main.tf
@@ -21,10 +21,8 @@ resource "azurerm_iothub" "iot_hub" {
     capacity = "1"
   }
 
-  route {
-    name           = "defaultroute"
+  fallback_route {
     source         = "DeviceMessages"
-    condition      = "true"
     endpoint_names = ["events"]
     enabled        = true
   }


### PR DESCRIPTION
- remove the default route created in the IoT Hub and enable the fallback route (this would be consistent with the default behavior when creating an IoT Hub through Azure portal or CLI - https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c#built-in-endpoint-as-a-routing-endpoint)
- remove deprecated comment
