### PR TITLE
Update terraform providers

### DIFF
--- a/terraform-dps/main.tf
+++ b/terraform-dps/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.65.0"
+      version = "=3.14.0"
     }
   }
 }

--- a/terraform-dps/modules/iot-edge/main.tf
+++ b/terraform-dps/modules/iot-edge/main.tf
@@ -2,12 +2,10 @@ terraform {
   required_providers {
     shell = {
       source  = "scottwinkler/shell"
-      version = "1.7.7"
+      version = "1.7.10"
     }
   }
 }
-
-provider "shell" {}
 
 resource "random_string" "vm_user_name" {
   length  = 10
@@ -80,9 +78,9 @@ resource "tls_private_key" "vm_ssh" {
 }
 
 resource "local_file" "ssh" {
-  sensitive_content = tls_private_key.vm_ssh.private_key_pem
-  filename          = "../.ssh/id_rsa"
-  file_permission   = "600"
+  content         = tls_private_key.vm_ssh.private_key_pem
+  filename        = "../.ssh/id_rsa"
+  file_permission = "600"
 }
 
 resource "shell_script" "create_iot_edge_config" {

--- a/terraform-dps/modules/iot-hub/main.tf
+++ b/terraform-dps/modules/iot-hub/main.tf
@@ -1,14 +1,11 @@
-
 terraform {
   required_providers {
     shell = {
       source  = "scottwinkler/shell"
-      version = "1.7.7"
+      version = "1.7.10"
     }
   }
 }
-
-provider "shell" {}
 
 data "azurerm_subscription" "current" {
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.45.1"
+      version = "=3.14.0"
     }
   }
 }

--- a/terraform/modules/iot-hub/main.tf
+++ b/terraform/modules/iot-hub/main.tf
@@ -2,13 +2,10 @@ terraform {
   required_providers {
     shell = {
       source  = "scottwinkler/shell"
-      version = "1.7.7"
+      version = "1.7.10"
     }
   }
 }
-
-provider "shell" {}
-
 
 resource "azurerm_iothub" "iot_hub" {
   name                          = "${var.resource_prefix}-iot-hub"


### PR DESCRIPTION
Was getting `incompatible provider version` errors on Mac M1 (darwin_arm64), so needed to update some of the providers (and its breaking changes):

```
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/scottwinkler/shell v1.7.7 does not have a package available for your
│ current platform, darwin_arm64.
╷
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/hashicorp/azurerm v2.45.1 does not have a package available for your
│ current platform, darwin_arm64.
```