### PR TITLE
docs: add warning about line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Terraform template to deploy IoT Edge enabled VM
 
-Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub, IoT Hub device on Azure. Iot Edge VM deployment is based on the ARM varient found at https://aka.ms/iotedge-vm-deploy and https://github.com/Azure/iotedge-vm-deploy.
+Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub, IoT Hub device on Azure. Iot Edge VM deployment is based on the ARM variant found at <https://aka.ms/iotedge-vm-deploy> and <https://github.com/Azure/iotedge-vm-deploy>.
 
 ## Deploy IoTEdge with terraform
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 ## Terraform template to deploy IoT Edge enabled VM
 
-Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub, IoT Hub device on Azure. Iot Edge VM deployment is based on the ARM variant found at <https://aka.ms/iotedge-vm-deploy> and <https://github.com/Azure/iotedge-vm-deploy>.
+Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub,
+IoT Hub device on Azure. Iot Edge VM deployment is based on the ARM variant
+found at <https://aka.ms/iotedge-vm-deploy> and
+<https://github.com/Azure/iotedge-vm-deploy>.
 
 ## Deploy IoTEdge with terraform
 
-1. [Authenticate to Azure with Terraform Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
+1. [Authenticate to Azure with Terraform Azure
+   Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
 2. Login to Azure CLI
 3. Apply terraform
 
@@ -15,24 +19,30 @@ Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub, Io
     apply terraform
     ```
 
-> **NOTE**: in case there are errors when executing the `scripts/terraform/register_iot_edge_device.sh`
-> script, ensure the correct line endings (`LF`) are used, depending on the environment.
-> To learn more about how to configure line endings for your repository, check
-> [GitHub Docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).
+> **NOTE**: in case there are errors when executing the
+> `scripts/terraform/register_iot_edge_device.sh` script, ensure the correct
+> line endings (`LF`) are used, depending on the environment. To learn more
+> about how to configure line endings for your repository, check [GitHub
+> Docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).
 
 ## Deploy IoTEdge and DPS with terraform
 
 1. Create Root & Intermediary certificates
 
-    Create root and intermediary certificates for device provisioning service and IoT Edge:
+    Create root and intermediary certificates for device provisioning service
+    and IoT Edge:
 
     ```bash
     make dps-cert-gen
     ```
 
-    The certificates will be created within the [`certs/gen/certs`]([certs/gen/certs) directory. More information of how certificates are generated can be found in the [certificate README](certs/README.md).
+    The certificates will be created within the
+    [`certs/gen/certs`]([certs/gen/certs) directory. More information of how
+    certificates are generated can be found in the [certificate
+    README](certs/README.md).
 
-2. [Authenticate to Azure with Terraform Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
+2. [Authenticate to Azure with Terraform Azure
+   Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
 3. Login to Azure CLI
 4. Apply terraform
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub, Io
     apply terraform
     ```
 
+> **NOTE**: in case there are errors when executing the `scripts/terraform/register_iot_edge_device.sh`
+> script, ensure the correct line endings (`LF`) are used, depending on the environment.
+> To learn more about how to configure line endings for your repository, check
+> [GitHub Docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).
+
 ## Deploy IoTEdge and DPS with terraform
 
 1. Create Root & Intermediary certificates

--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 ## Terraform template to deploy IoT Edge enabled VM
 
-Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub,
-IoT Hub device on Azure. Iot Edge VM deployment is based on the ARM variant
-found at <https://aka.ms/iotedge-vm-deploy> and
-<https://github.com/Azure/iotedge-vm-deploy>.
+Terraform template to provision an IoT Edge enabled virtual machine, IoT Hub, IoT Hub device on Azure. Iot Edge VM deployment is based on the ARM variant found at <https://aka.ms/iotedge-vm-deploy> and <https://github.com/Azure/iotedge-vm-deploy>.
 
 ## Deploy IoTEdge with terraform
 
-1. [Authenticate to Azure with Terraform Azure
-   Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
+1. [Authenticate to Azure with Terraform Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
 2. Login to Azure CLI
 3. Apply terraform
 
@@ -19,30 +15,24 @@ found at <https://aka.ms/iotedge-vm-deploy> and
     apply terraform
     ```
 
-> **NOTE**: in case there are errors when executing the
-> `scripts/terraform/register_iot_edge_device.sh` script, ensure the correct
-> line endings (`LF`) are used, depending on the environment. To learn more
-> about how to configure line endings for your repository, check [GitHub
-> Docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).
+> **NOTE**: in case there are errors when executing the `scripts/terraform/register_iot_edge_device.sh`
+> script, ensure the correct line endings (`LF`) are used, depending on the environment.
+> To learn more about how to configure line endings for your repository, check
+> [GitHub Docs](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings).
 
 ## Deploy IoTEdge and DPS with terraform
 
 1. Create Root & Intermediary certificates
 
-    Create root and intermediary certificates for device provisioning service
-    and IoT Edge:
+    Create root and intermediary certificates for device provisioning service and IoT Edge:
 
     ```bash
     make dps-cert-gen
     ```
 
-    The certificates will be created within the
-    [`certs/gen/certs`]([certs/gen/certs) directory. More information of how
-    certificates are generated can be found in the [certificate
-    README](certs/README.md).
+    The certificates will be created within the [`certs/gen/certs`]([certs/gen/certs) directory. More information of how certificates are generated can be found in the [certificate README](certs/README.md).
 
-2. [Authenticate to Azure with Terraform Azure
-   Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
+2. [Authenticate to Azure with Terraform Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#authenticating-to-azure)
 3. Login to Azure CLI
 4. Apply terraform
 


### PR DESCRIPTION
When cloning the code on a windows machine, and then running the devcontainer, it can happen that the line ending of the files is not what is expected on a linux environment.
This causes issues when executing the `register_iot_edge_device.sh` script. The file needs to have `LF` line endings.

Added a short warning to the README, as well as some small formatting.